### PR TITLE
Fix test_newton_solver.py: pass JointIndex to adapter.post_joint_map

### DIFF
--- a/source/geniesim_ros/src/ros_ws/src/genie_sim_engine/scripts/tools/test_newton_solver.py
+++ b/source/geniesim_ros/src/ros_ws/src/genie_sim_engine/scripts/tools/test_newton_solver.py
@@ -1293,7 +1293,11 @@ def main() -> int:
             logger.warn(f"[tools] init-pose keyframe step failed (continuing): {exc!r}")
 
     # === STEP 8: Adapter post_joint_map (selective PD) =============
-    adapter.post_joint_map(model, joint_name_to_dof, control, logger)
+    # Adapters expect the engine's JointIndex snapshot (they call
+    # ``jindex.name_to_dof()``), not the raw dict computed above.
+    from engine.newton.joint_index import JointIndex
+
+    adapter.post_joint_map(model, JointIndex(model), control, logger)
 
     # === STEP 9: Sync BOTH states with model.joint_q ===============
     # Production lifecycle.py:344-352 seeds state_0 AND state_1 so the


### PR DESCRIPTION
## Problem

`tools/test_newton_solver.py` passes the raw `joint_name_to_dof` dict to `adapter.post_joint_map()`, but the adapter API expects the engine's `JointIndex` snapshot — `FeatherstoneAdapter.post_joint_map` and `AVBDAdapter.post_joint_map` both call `jindex.name_to_dof()` on the argument. Running the tool with `--solver featherstone` (or `avbd`) crashes at STEP 8:

```
File ".../engine/newton/adapters/featherstone.py", line 237, in post_joint_map
    joint_name_to_dof = jindex.name_to_dof() if jindex is not None else {}
AttributeError: 'dict' object has no attribute 'name_to_dof'
```

It looks like the tool drifted from the adapter API when `post_joint_map` moved to taking a `JointIndex`.

## Fix

Construct `JointIndex(model)` from the finalized model and pass that, matching what the production engine lifecycle does. One call site, 5 lines.

## Testing

With this fix, `--solver featherstone` and `--solver mujoco-warp` runs on a 2-DOF pendulum URDF complete 100 frames at 100 Hz with finite joint states and correct PD hold / `--cmd-mode wbc` tracking (tested against Newton 1.3.0 / Warp 1.14.0 on a CPU-only build, macOS arm64 — the tool's advertised no-ROS, no-Kit mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)