### PR TITLE
data_collection: extract process tracking logic is incorrect

### DIFF
--- a/source/data_collection/server/command_controller.py
+++ b/source/data_collection/server/command_controller.py
@@ -1083,15 +1083,17 @@ class CommandController:
 
                 total_time = 0
                 clean_once = True
-                while len(self.extract_process) > MAX_EXTRACT_PROCESS_NUM or clean_once:
-                    new_process = []
+                while len(self.extract_process) >= MAX_EXTRACT_PROCESS_NUM or clean_once:
+                    running_process = []
                     clean_once = False
                     for p, log_file in self.extract_process:
-                        if p.poll():
-                            new_process.append((p, log_file))
+                        if p.poll() is None:
+                            # poll() returns None while the process is still running
+                            running_process.append((p, log_file))
                         else:
+                            # process finished (success or failure); clean it up
                             log_file.close()
-                    self.extract_process = new_process
+                    self.extract_process = running_process
                     time.sleep(0.1)
                     total_time += 0.1
                     if total_time > 120:


### PR DESCRIPTION

In `command_controller.py`, running extraction processes are removed from `self.extract_process`:

```python
if p.poll():
    new_process.append((p, log_file))
else:
    log_file.close()
```

Popen.poll() returns None while the process is running, so the logic should be reversed:
```python
if p.poll() is None:
    new_process.append((p, log_file))
else:
    log_file.close()
```

This makes MAX_EXTRACT_PROCESS_NUM ineffective and prevents handle_exit() from waiting for active extractors.
The limit condition may also need to use >=, since a new process is launched after the check. Note: dropping a still-running process also closes its log file early, so the extractor keeps writing to a closed fd. The `>=` fix keeps live extractors below `MAX_EXTRACT_PROCESS_NUM` (currently they can reach MAX + 1).
