### PR TITLE
fix(data_collection): avoid redundant JPEG re-encode when extracting RGB frames

### DIFF
--- a/source/data_collection/server/recording/extract_ros_bag.py
+++ b/source/data_collection/server/recording/extract_ros_bag.py
@@ -332,6 +332,9 @@ class RosExtrater:
         self.fps = task_info["fps"]
         self.with_img = True
         self.with_video = True
+        self.rgb_write_mode = task_info.get("rgb_write_mode", "passthrough")
+        if self.rgb_write_mode not in {"opencv", "passthrough"}:
+            raise ValueError(f"Unsupported RGB write mode: {self.rgb_write_mode}")
         self.with_senmatic = is_senmatic
         self.light_config = task_info["light_config"]
         self.gripper_names = task_info["gripper_names"]
@@ -1055,11 +1058,23 @@ class RosExtrater:
                             stamp[file_name] = (float)(msg.header.stamp.sec) + (float)(
                                 msg.header.stamp.nanosec
                             ) * np.power(10.0, -9)
-                            img = message_to_cvimage(msg, "bgr8")  # change encoding type if needed
-                            if img is None or img.size == 0:
-                                logger.info(f"⚠️ empty image, skip key={key} ts={ts}")
-                                continue
-                            cv2.imwrite(rgb_dir + "/{}.jpg".format(file_name), img)
+                            image_path = rgb_dir + "/{}.jpg".format(file_name)
+                            if self.rgb_write_mode == "opencv":
+                                # Decode the JPEG and re-encode it (legacy path).
+                                img = message_to_cvimage(msg, "bgr8")
+                                if img is None or img.size == 0:
+                                    logger.info(f"⚠️ empty image, skip key={key} ts={ts}")
+                                    continue
+                                cv2.imwrite(image_path, img)
+                            else:
+                                # The CompressedImage payload is already JPEG; write the
+                                # raw bytes straight to disk to avoid a redundant
+                                # decode + re-encode (and a second lossy pass).
+                                if msg.data.size == 0:
+                                    logger.info(f"⚠️ empty image, skip key={key} ts={ts}")
+                                    continue
+                                with open(image_path, "wb") as image_file:
+                                    image_file.write(msg.data.tobytes())
                         min_value = min(stamp.values())
                         for key in stamp:
                             stamp[key] = min_value


### PR DESCRIPTION
## Problem

The RGB camera stream is published via `image_transport republish raw compressed`, so every `sensor_msgs/CompressedImage` in the bag already carries JPEG bytes. When extracting, the code nonetheless ran `message_to_cvimage()` (cv2.imdecode) and then `cv2.imwrite("*.jpg")` on each frame — decoding and re-encoding every
frame. This is pure overhead and adds a second lossy JPEG pass on top of the one image_transport already performed.

## Change

Add an `rgb_write_mode` option (default `passthrough`) that writes the raw CompressedImage bytes straight into the existing `camera/<frame>/*.jpg` layout, so both downstream consumers (this extractor's ffmpeg step and `agibot_to_lerobot`) keep working unchanged. The legacy decode + re-encode path remains available via `rgb_write_mode: "opencv"`.

Only the CompressedImage path is touched; the raw Image, depth and semantic paths are unchanged.

## Benchmark

Depth-enabled episode, 578 frames, 5 RGB + 3 depth cameras, extractor run inside the data_collection container (medians consistent across repeats).

| Case | RGB handling | MP4 | write_frames | total | CPU (user+sys) | Output |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| opencv decode + re-encode | off | | 39.95 s | 49.11 s | 168.5 s | 2.065 GiB |
| **passthrough (this PR)** | off | | **16.89 s** | **26.23 s** | **76.6 s** | 2.060 GiB |

- `write_frames`: **39.95 s → 16.89 s (2.36× faster, −58%)**, ~23 s saved.
- total extraction (video off): **49.11 s → 26.23 s (1.87× faster, −47%)**.
- CPU time: **168.5 s → 76.6 s**.
- Output size essentially unchanged (2.065 → 2.060 GiB), confirming no quality regression from removing the second lossy JPEG pass.
- On the full default pipeline (MP4 on) end-to-end drops **68.8 s → 45.7 s (1.51×)**.

The absolute RGB saving (~23 s) is independent of depth; with depth off the same change cuts `write_frames` from 25.2 s to 1.0 s. Here depth PNG writing (~16 s) is a shared floor in both modes, which is why the ratio is smaller but still large.
