### PR TITLE
fix benchmark category examples

### DIFF
--- a/source/geniesim_benchmark/README.md
+++ b/source/geniesim_benchmark/README.md
@@ -61,13 +61,13 @@ backward compatible with existing inference servers.
 ```bash
 geniesim benchmark categories         # show category counts
 geniesim benchmark robots             # show robot counts
-geniesim benchmark list --robot=g2op --category=instruction_following
+geniesim benchmark list --robot=g2op --category=if
 ```
 
 ### Batch-evaluate a sweep
 
 ```bash
-geniesim benchmark batch --category=instruction_following --robot=g2op
+geniesim benchmark batch --category=if --robot=g2op
 ```
 
 ### Convert collected datasets between formats

--- a/source/geniesim_benchmark/USAGE.md
+++ b/source/geniesim_benchmark/USAGE.md
@@ -27,7 +27,7 @@ The whole benchmark is driven by the `geniesim benchmark` CLI verb:
 # 1. Discover what's available
 geniesim benchmark categories                       # category counts (instruction / manipulation / spatial / …)
 geniesim benchmark robots                           # robot/embodiment counts
-geniesim benchmark list --robot=g2op --category=instruction_following
+geniesim benchmark list --robot=g2op --category=if
 
 # 2. Probe your inference server BEFORE launching a sim (catches protocol / NaN issues early)
 geniesim benchmark check-inference --infer-host=<IP>:8999
@@ -39,7 +39,7 @@ geniesim benchmark run g2op_if_pick_block_color --infer-host=<IP>:8999 \
   --app.headless=true --benchmark.record=true --benchmark.num_episode=20 --benchmark.seed=0
 
 # 4. Batch-evaluate a whole sweep (one category × robot)
-geniesim benchmark batch --category=instruction_following --robot=g2op
+geniesim benchmark batch --category=if --robot=g2op
 ```
 
 > 🖼️ **History image observations (corobot):** the runtime will feed a rolling


### PR DESCRIPTION
## Summary

Replace `--category=instruction_following` with the actual config category token `--category=if` in the benchmark README and usage examples.

`geniesim_cli.commands.benchmark._split_name()` derives a category from the second config-name token, and `_KNOWN_CATEGORIES` contains `if`, not `instruction_following`. The previous examples therefore returned no matching configs.

## Verification

Using the source packages on `PYTHONPATH`:

```text
geniesim benchmark list --robot=g2op --category=if
```

returns 10 runnable `g2op_if_*` configs.

Documentation-only change; no runtime behavior is modified.