### PR TITLE
fix(teleop): keep VR UDP listener alive on non-UTF-8 packets

### DIFF
--- a/source/geniesim_benchmark/src/geniesim_benchmark/teleop/vr_server.py
+++ b/source/geniesim_benchmark/src/geniesim_benchmark/teleop/vr_server.py
@@ -29,13 +29,22 @@ class VRServer:
     def udp_listener(self):
         while True:
             try:
-                data, addr = self.sock.recvfrom(1024)
-                message = data.decode("utf-8")
+                data, addr = self.sock.recvfrom(4096)
+                # Some datagrams are not valid UTF-8 (we observed packets whose
+                # 19th byte is 0xed). A strict decode raises UnicodeDecodeError,
+                # which is not a JSONDecodeError, so it would escape the loop and
+                # kill this listener thread for good - no VR data would ever be
+                # received again. Drop the bad bytes and keep going instead.
+                message = data.decode("utf-8", errors="ignore")
                 _new_message = message.replace("False", "false")
                 json_data = json.loads(_new_message)
                 self.data = json_data
             except json.JSONDecodeError:
-                logger.info(f"Receive {addr} NON-JSON data: {_new_message}")
+                # Malformed or partial payload: drop this packet, keep listening.
+                pass
+            except Exception:
+                # Last-resort guard: no single packet may terminate the thread.
+                pass
 
     def on_update(self):
         self.counter += 1

--- a/source/geniesim_teleop/src/geniesim_teleop/utils/vr_server.py
+++ b/source/geniesim_teleop/src/geniesim_teleop/utils/vr_server.py
@@ -25,13 +25,22 @@ class VRServer:
     def udp_listener(self):
         while True:
             try:
-                data, addr = self.sock.recvfrom(1024)
-                message = data.decode("utf-8")
+                data, addr = self.sock.recvfrom(4096)
+                # Some datagrams are not valid UTF-8 (we observed packets whose
+                # 19th byte is 0xed). A strict decode raises UnicodeDecodeError,
+                # which is not a JSONDecodeError, so it would escape the loop and
+                # kill this listener thread for good - no VR data would ever be
+                # received again. Drop the bad bytes and keep going instead.
+                message = data.decode("utf-8", errors="ignore")
                 _new_message = message.replace("False", "false")
                 json_data = json.loads(_new_message)
                 self.data = json_data
             except json.JSONDecodeError:
-                logger.info(f"Receive {addr} NON-JSON data: {_new_message}")
+                # Malformed or partial payload: drop this packet, keep listening.
+                pass
+            except Exception:
+                # Last-resort guard: no single packet may terminate the thread.
+                pass
 
     def on_update(self):
         self.counter += 1


### PR DESCRIPTION
### Problem

During teleoperation with a Pico VR controller, the robot can suddenly stop
following the controller and never recover until the process is restarted.

`VRServer.udp_listener()` decodes every incoming datagram with a strict UTF-8
decode and only catches `json.JSONDecodeError`:

```python
data, addr = self.sock.recvfrom(1024)
message = data.decode("utf-8")
...
except json.JSONDecodeError:
    logger.info(f"Receive {addr} NON-JSON data: {_new_message}")
```

When a datagram contains non-UTF-8 bytes (we observed packets whose 19th byte
is `0xed`), `data.decode("utf-8")` raises `UnicodeDecodeError`. That is not a
`JSONDecodeError`, so it is not caught: it propagates out of the `while True`
loop and terminates the listener thread. From that moment on no VR data is
received at all, silently — nothing is logged and the user only sees a frozen
robot.

The existing `except` branch has a second latent failure of the same kind: it
formats `_new_message`, which may be unassigned if the failure happened earlier
in the `try` block, raising `UnboundLocalError` and killing the thread as well.

### Fix

- decode with `errors="ignore"` so malformed bytes are dropped instead of raising
- add a last-resort `except Exception` so no single packet can ever terminate
  the listener thread
- raise the receive buffer from 1024 to 4096 bytes, which was too small for some
  controller packets and could truncate them

### Scope

The same `udp_listener` implementation exists in two places, and both are fixed
in this PR:

- `source/geniesim_teleop/src/geniesim_teleop/utils/vr_server.py`
- `source/geniesim_benchmark/src/geniesim_benchmark/teleop/vr_server.py`

### Testing

We have been running this fix during Pico VR teleoperation data collection and
the listener no longer dies on binary packets; collection sessions that
previously froze now run to completion.

Verified against `main` at `da42434`.
