### PR TITLE
fix(teleop): import pynput lazily so teleop starts on headless contai…

### DIFF
--- a/source/geniesim_teleop/src/geniesim_teleop/teleop.py
+++ b/source/geniesim_teleop/src/geniesim_teleop/teleop.py
@@ -11,7 +11,6 @@ from geniesim_teleop.utils.logger import Logger
 from geniesim_teleop.utils.ros_utils import RosUtils
 from geniesim_teleop.utils.name_utils import *
 from geniesim_teleop.devices.pico_device import PicoDevice
-from pynput import keyboard
 from geometry_msgs.msg import Pose
 
 import os, sys, argparse, math
@@ -344,6 +343,13 @@ class TeleOp(object):
             self.is_recording = True
 
     def sub_keyboard_event(self):
+        # Imported lazily: pynput opens an X connection at import time and raises
+        # ImportError when no display is available, which is the normal case for a
+        # headless container. Keyboard control is optional (the call site below is
+        # commented out), so importing it at module level would break teleop for
+        # everyone who does not need it.
+        from pynput import keyboard
+
         self.pressed_keys = set()
 
         def on_press(key):


### PR DESCRIPTION
### Problem

`source/geniesim_teleop/src/geniesim_teleop/teleop.py` imports pynput at module
level (line 14):

```python
from pynput import keyboard
```

pynput opens an X connection **at import time**. When no display is reachable —
the normal situation inside a headless container — the import itself fails:

```
ImportError: this platform is not supported: ('failed to acquire X connection:
Bad display name ""', DisplayNameError(''))
```

Reproduced with pynput 1.8.2:

```console
$ python3 -c "from pynput import keyboard"          # DISPLAY set
(ok)

$ env -u DISPLAY python3 -c "from pynput import keyboard"
ImportError: this platform is not supported: ('failed to acquire X connection:
Bad display name ""', DisplayNameError(''))
```

Because this happens during import, it takes down `teleop.py` before any teleop
code runs — the failure is unrelated to what the user is actually trying to do.

### Why this affects everyone, not just keyboard users

The `keyboard` name has exactly one consumer, `sub_keyboard_event()`, and that
method's only call site is commented out (line 398):

```python
# self.sub_keyboard_event()
```

So the keyboard feature is disabled by default, yet every user pays for its
dependency at startup.

### Fix

Move the import into `sub_keyboard_event()`, the sole consumer. Behaviour is
unchanged when a display is available; teleop now starts on headless containers.

Verified against `main` at `da42434`.

