### PR TITLE
fix(ros): spin server_ros_node from a background executor, not a non-…

### DIFF
--- a/source/geniesim_benchmark/src/geniesim_benchmark/app/controllers/api_core.py
+++ b/source/geniesim_benchmark/src/geniesim_benchmark/app/controllers/api_core.py
@@ -14,6 +14,7 @@ import subprocess
 import signal, shutil
 from pxr import Usd, UsdGeom, UsdShade, Sdf, Gf, UsdPhysics, PhysxSchema, UsdLux
 import rclpy
+from rclpy.executors import SingleThreadedExecutor
 
 import omni
 import omni.usd
@@ -70,6 +71,9 @@ class APICore:
         self.task_queue_on_render_loop = queue.Queue()
         self.task_queue_on_physics_loop = queue.Queue()
         self.benchmark_ros_node = None
+        # Background executor that spins server_ros_node (see _start_server_ros_spin)
+        self._server_ros_executor = None
+        self._server_ros_spin_thread = None
         self.exit = False
         self.ui_builder: UIBuilder = ui_builder
         self.data = None
@@ -982,6 +986,16 @@ class APICore:
                 logger.warning(f"Failed to destroy benchmark_ros_node: {e}")
             self.benchmark_ros_node = None
 
+        # Stop the spin thread before destroying the node it is spinning
+        if getattr(self, "_server_ros_executor", None) is not None:
+            try:
+                self._server_ros_executor.shutdown()
+                logger.info("server_ros_executor shutdown")
+            except Exception as e:
+                logger.warning(f"Failed to shutdown server_ros_executor: {e}")
+            self._server_ros_executor = None
+            self._server_ros_spin_thread = None
+
         if hasattr(self, "server_ros_node") and self.server_ros_node is not None:
             try:
                 self.server_ros_node.destroy_node()
@@ -1471,6 +1485,7 @@ class APICore:
             self.pub_depth_camera()
         if self.enable_ros and not self.ros_node_initialized:
             self.server_ros_node = ServerNode(robot_name=self.robot_name)
+            self._start_server_ros_spin()
             # joint_states
             logger.info(f"sensor_ros.publish_joint {self.robot_prim_path} {self.robot_name}")
             self.sensor_base.publish_joint(robot_prim=self.robot_prim_path)
@@ -2729,6 +2744,47 @@ class APICore:
         else:
             raise ValueError("Undefined robot")
 
+    def _start_server_ros_spin(self):
+        """Spin server_ros_node from a persistent background executor.
+
+        It used to be spun by `rclpy.spin_once(timeout_sec=0)` inside on_ros_tick,
+        i.e. a non-blocking poll driven by the physics callback. That poll can miss
+        messages entirely: DDS often delivers just after it returns, so the data sits
+        unread in the reader queue. When that happens the simulation stops reacting to
+        every /sim/* topic -- pressing the teleop record button does nothing, because
+        /sim/is_recording never reaches _on_recording.
+
+        This repo already documents the same failure mode and the same fix in
+        rlinf_geniesim/renderer/rl_renderer.py: "spin_once(timeout_sec=0.0) in the
+        render callback is unreliable with many publishers ... Instead, run a
+        persistent ... executor in a background thread so all subscriber callbacks
+        fire as soon as messages arrive, independent of render timing."
+
+        Only server_ros_node is moved: its callbacks just assign a bool that is read
+        back through a locked getter (see ServerNode.callback_playback /
+        callback_recording / callback_reset and the matching get_* methods) and touch
+        no Isaac Sim API, so they are safe off the physics thread. Note these
+        callbacks already ran on the physics thread while the getters were called
+        from the render loop, so cross-thread access is not new here.
+        benchmark_ros_node is left as-is.
+        """
+        self._server_ros_executor = SingleThreadedExecutor()
+        self._server_ros_executor.add_node(self.server_ros_node)
+        self._server_ros_spin_thread = threading.Thread(
+            target=self._spin_server_ros_executor,
+            daemon=True,
+            name="geniesim_server_ros_spin",
+        )
+        self._server_ros_spin_thread.start()
+        logger.info("server_ros_node spin thread started")
+
+    def _spin_server_ros_executor(self):
+        try:
+            self._server_ros_executor.spin()
+        except Exception as e:
+            # shutdown() makes spin() return through here as well, so info level
+            logger.info(f"server_ros_node spin thread exited: {e}")
+
     def on_ros_tick(self, step_size):
         # Sim-tick: refresh robot_interface caches every step, regardless of
         # whether ROS is enabled. The recorder reads _img_data_cache from here.
@@ -2743,7 +2799,8 @@ class APICore:
             return
 
         if self.ros_node_initialized:
-            rclpy.spin_once(self.server_ros_node, timeout_sec=0)
+            # server_ros_node is spun by the background executor started in
+            # _start_server_ros_spin(); polling it here misses messages.
             if self.benchmark_ros_node is not None:
                 rclpy.spin_once(self.benchmark_ros_node, timeout_sec=0)
 


### PR DESCRIPTION
## Problem

`APICore.on_ros_tick` polls `server_ros_node` with `rclpy.spin_once(timeout_sec=0)`
from the physics callback. That poll can miss messages entirely: DDS often delivers
just after the non-blocking wait returns, leaving the data unread in the reader queue.

When that happens the simulation stops reacting to **every** `/sim/*` topic. The
practical consequence is that teleop data collection breaks completely -- pressing the
record button does nothing, because `/sim/is_recording` never reaches `_on_recording`,
so no episode can be recorded at all. Nothing in the logs indicates a problem, which
makes it hard to diagnose.

## Evidence

Measured on Isaac Sim 5.1.0 / ROS 2 Jazzy / `rmw_cyclonedds_cpp`, reproduced across two
clean restarts (so not a transient):

| Observation | Result |
|---|---|
| 103 messages published to `/sim/stop_episode` | another rclpy node in the same ROS graph received **103/103**, the simulation received **0** |
| 40 messages to `/sim/is_recording`, plus the teleop process republishing at 5 Hz on its own | no reaction, no recording started |
| Published from Isaac Sim's own bundled rclpy (same DDS build, same env vars) | still **0** |
| `/clock` published by `server_ros_node`, measured externally | **39.458 Hz** -- publishing works, only receiving is broken |
| DDS GID prefix of the `/clock` publisher vs the `/sim/stop_episode` subscription | identical -> same live entity, not a stale participant |
| Robot motion during all of this | worked, because joint commands are delivered by the Isaac ROS 2 bridge OmniGraph node, which does not go through rclpy |

The publish/receive asymmetry is the key signal: publishing needs no spin, subscribing
does.

## Why this fix

This repository already documents the same failure mode and prescribes the same fix, in
`source/rlinf_geniesim/renderer/rl_renderer.py`:

> `spin_once(timeout_sec=0.0)` in the render callback is unreliable with many
> publishers: odd-indexed envs consistently miss their messages because DDS delivers
> them just after the non-blocking poll returns. Instead, run a persistent
> MultiThreadedExecutor in a background thread so all subscriber callbacks fire as soon
> as messages arrive, independent of render timing.

This PR applies that conclusion to `server_ros_node`.

## Scope

Deliberately minimal:

- Only `server_ros_node` is moved to a persistent `SingleThreadedExecutor` running in a
  daemon thread. `benchmark_ros_node` keeps its existing polling.
- `ServerNode`'s callbacks only assign a bool that is read back through a locked getter
  and touch no Isaac Sim API, so they are safe off the physics thread. They already ran
  on the physics thread while the getters were called from the render loop, so
  cross-thread access is not new here.
- The executor is shut down before the node is destroyed, otherwise the spin thread
  would touch a destroyed node during teardown.

## Testing and limitations

- Verified on my setup (Isaac Sim 5.1.0, ROS 2 Jazzy, cyclonedds, G2 + teleop
  collection flow): after the change the simulation receives 3/3 published messages and
  runs the corresponding handler; the record button works again.
- **Honest caveat 1:** my working tree predates the 3.2.0 directory restructure. The
  patch in this PR is the same change applied to current `main`; I verified the target
  code is identical there (`api_core.py`, `on_ros_tick`) and that it compiles, but I
  have not run current `main` end to end.
- **Honest caveat 2:** I cannot explain why the old code worked on my machine earlier
  and then stopped without any relevant change (I ruled out code changes to this path,
  container/image rebuilds and launch-environment differences). A non-blocking poll is
  inherently timing-dependent, and this change removes that dependency rather than
  explaining it. I did not want to claim a root cause I could not demonstrate.

Happy to adjust the scope (e.g. move `benchmark_ros_node` as well, or use a
`MultiThreadedExecutor` to match `rl_renderer.py` more closely) if you prefer.
